### PR TITLE
Add support for discovering multiple households

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -22,6 +22,7 @@ from .data_structures import (
     DidlObject, DidlPlaylistContainer, DidlResource,
     Queue, to_didl_string
 )
+from .cache import Cache
 from .data_structures_entry import from_didl_string
 from .exceptions import (
     SoCoSlaveException, SoCoUPnPException, NotSupportedException,
@@ -31,7 +32,6 @@ from .music_library import MusicLibrary
 from .services import (
     DeviceProperties, ContentDirectory, RenderingControl, AVTransport,
     ZoneGroupTopology, AlarmClock, SystemProperties, MusicServices,
-    zone_group_state_shared_cache,
 )
 from .utils import (
     really_utf8, camel_to_underscore, deprecated
@@ -265,7 +265,8 @@ class SoCo(_SocoSingletonBase):
         self._uid = None
         self._household_id = None
         self._visible_zones = set()
-        self._zgs_cache = None
+        self._zgs_cache = Cache(default_timeout=5)
+        self._zgs_result = None
 
         _LOG.debug("Created SoCo instance for ip: %s", ip_address)
 
@@ -949,6 +950,8 @@ class SoCo(_SocoSingletonBase):
             ip_addr = member_attribs['Location'].\
                 split('//')[1].split(':')[0]
             zone = config.SOCO_CLASS(ip_addr)
+            # share our cache
+            zone._zgs_cache = self._zgs_cache
             # uid doesn't change, but it's not harmful to (re)set it, in case
             # the zone is as yet unseen.
             zone._uid = member_attribs['UUID']
@@ -966,10 +969,10 @@ class SoCo(_SocoSingletonBase):
         # need to repeat all the XML parsing. In addition, switch on network
         # caching for a short interval (5 secs).
         zgs = self.zoneGroupTopology.GetZoneGroupState(
-            cache_timeout=5)['ZoneGroupState']
-        if zgs == self._zgs_cache:
+            cache=self._zgs_cache)['ZoneGroupState']
+        if zgs == self._zgs_result:
             return
-        self._zgs_cache = zgs
+        self._zgs_result = zgs
         tree = XML.fromstring(zgs.encode('utf-8'))
         # Empty the set of all zone_groups
         self._groups.clear()
@@ -1080,7 +1083,7 @@ class SoCo(_SocoSingletonBase):
             ('CurrentURI', 'x-rincon:{0}'.format(master.uid)),
             ('CurrentURIMetaData', '')
         ])
-        zone_group_state_shared_cache.clear()
+        self._zgs_cache.clear()
         self._parse_zone_group_state()
 
     def unjoin(self):
@@ -1094,7 +1097,7 @@ class SoCo(_SocoSingletonBase):
         self.avTransport.BecomeCoordinatorOfStandaloneGroup([
             ('InstanceID', 0)
         ])
-        zone_group_state_shared_cache.clear()
+        self._zgs_cache.clear()
         self._parse_zone_group_state()
 
     def switch_to_line_in(self, source=None):

--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -94,13 +94,6 @@ class Vartype(namedtuple('VartypeBase', 'datatype, default, list, range')):
         return self.datatype
 
 
-# A shared cache for ZoneGroupState. Each zone has the same info, so when a
-# SoCo instance is asked for group info, we can cache it and return it when
-# another instance is asked. To do this we need a cache to be shared between
-# instances
-zone_group_state_shared_cache = Cache()
-
-
 # pylint: disable=too-many-instance-attributes
 class Service(object):
 
@@ -777,12 +770,6 @@ class ZoneGroupTopology(Service):
 
     """Sonos zone group topology service, for functions relating to network
     topology, diagnostics and updates."""
-
-    def GetZoneGroupState(self, *args, **kwargs):
-        """Overrides default handling to use the global shared zone group state
-        cache, unless another cache is specified."""
-        kwargs['cache'] = kwargs.get('cache', zone_group_state_shared_cache)
-        return self.send_command('GetZoneGroupState', *args, **kwargs)
 
 
 class GroupManagement(Service):


### PR DESCRIPTION
Add an `all_households` option to `discover()` which will keep the listener running for one second after discovering the first speaker. With multiple Sonos households on the network, this allows us to discover them all rather than just the one that we see first.

A blocker for this is that we currently maintain a global state cache that is invalid when a speaker from a different household is accessed. This PR removes the global variable and makes the cache per-household.