### PR TITLE
Ignore invalid data structures

### DIFF
--- a/pysonos/data_structures.py
+++ b/pysonos/data_structures.py
@@ -32,6 +32,7 @@ helpful.
 from __future__ import unicode_literals
 
 import sys
+import logging
 import textwrap
 import warnings
 
@@ -41,6 +42,8 @@ from .utils import really_unicode
 from .xml import (
     XML, ns_tag
 )
+
+log = logging.getLogger(__name__)  # pylint: disable=C0103
 
 # Due to cyclic import problems, we only import from_didl_string at runtime.
 # from data_structures_entry import from_didl_string
@@ -492,8 +495,11 @@ class DidlObject(with_metaclass(DidlMetaClass, object)):
         # Deal with any resource elements
         resources = []
         for res_elt in element.findall(ns_tag('', 'res')):
-            resources.append(
-                DidlResource.from_element(res_elt))
+            try:
+                resource = DidlResource.from_element(res_elt)
+                resources.append(resource)
+            except DIDLMetadataError as ex:
+                log.info("Ignored '%s' on '%s'", ex, XML.tostring(res_elt))
 
         # and the desc element (There is only one in Sonos)
         desc = element.findtext(ns_tag('', 'desc'))


### PR DESCRIPTION
There are well-known types of favorites that are currently not handled. This PR makes those items be ignored.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/temp/sonossources/lib/python3.6/site-packages/pysonos/music_library.py", line 165, in get_sonos_favorites
    return self.get_music_library_information(*args, **kwargs)
  File "/temp/sonossources/lib/python3.6/site-packages/pysonos/music_library.py", line 316, in get_music_library_information
    items = from_didl_string(response['Result'])
  File "/temp/sonossources/lib/python3.6/site-packages/pysonos/data_structures_entry.py", line 52, in from_didl_string
    item = cls.from_element(elt)
  File "/temp/sonossources/lib/python3.6/site-packages/pysonos/data_structures.py", line 496, in from_element
    DidlResource.from_element(res_elt))
  File "/temp/sonossources/lib/python3.6/site-packages/pysonos/data_structures.py", line 175, in from_element
    raise DIDLMetadataError('Could not create Resource from Element: '
pysonos.exceptions.DIDLMetadataError: Could not create Resource from Element: protocolInfo not found (required).
```