### PR TITLE
Asynchronous discovery

### DIFF
--- a/pysonos/__init__.py
+++ b/pysonos/__init__.py
@@ -12,7 +12,7 @@
 import logging
 
 from .core import SoCo
-from .discovery import discover
+from .discovery import discover, discover_thread
 from .exceptions import SoCoException, UnknownSoCoException
 
 # Will be parsed by setup.py to determine package metadata

--- a/pysonos/__init__.py
+++ b/pysonos/__init__.py
@@ -27,6 +27,7 @@ __license__ = 'MIT License'
 # but if you do, here is what you get:
 __all__ = [
     'discover',
+    'discover_thread',
     'SoCo',
     'SoCoException',
     'UnknownSoCoException',

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -38,6 +38,10 @@ class ZoneMock:
         self.all_zones = { 'ALL' }
         self.visible_zones = { 'VISIBLE' }
 
+    @property
+    def is_visible(self):
+        return True
+
 class TestDiscover:
     def test_discover(self, monkeypatch):
         # Create a fake socket, whose data is always a certain string


### PR DESCRIPTION
The topology cache can be out of sync when speakers are powered on/off. This PR adds `discover_thread()` which runs a callback for each speaker that responds within the timeout. We start a background thread so clients will not have to.