### PR TITLE
Avoid unhandled exception on events

### DIFF
--- a/pysonos/events.py
+++ b/pysonos/events.py
@@ -144,7 +144,10 @@ def parse_event_xml(xml_event):
                         # Wrap any parsing exception in a SoCoFault, so the
                         # user can handle it
                         try:
-                            value = from_didl_string(value)[0]
+                            didl = from_didl_string(value)
+                            if not didl:
+                                continue
+                            value = didl[0]
                         except SoCoException as original_exception:
                             log.debug("Event contains illegal metadata"
                                       "for '%s'.\n"


### PR DESCRIPTION
This should avoid the following traceback, reported while playing Pandora.

```
Exception happened during processing of request from ('10.0.200.12', 53021)
Traceback (most recent call last):
  File "/usr/lib/python3.6/socketserver.py", line 651, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.6/socketserver.py", line 361, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.6/socketserver.py", line 721, in __init__
    self.handle()
  File "/usr/lib/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/usr/lib/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "/srv/homeassistant/lib/python3.6/site-packages/pysonos/events.py", line 258, in do_NOTIFY
    variables = parse_event_xml(content)
  File "/srv/homeassistant/lib/python3.6/site-packages/pysonos/events.py", line 147, in parse_event_xml
    value = from_didl_string(value)[0]
IndexError: list index out of range
```
