### PR TITLE
Lower discover_thread default timeout to 2s

### DIFF
--- a/pysonos/discovery.py
+++ b/pysonos/discovery.py
@@ -160,7 +160,7 @@ def _discover_thread(callback,
 
 
 def discover_thread(callback,
-                    timeout=5,
+                    timeout=2,
                     include_invisible=False,
                     interface_addr=None):
     """ Return a started thread with a discovery callback. """


### PR DESCRIPTION
This still allows for two discovery packets and waiting an additional second for responses.