### PR TITLE
Add two data structures

### DIFF
--- a/pysonos/data_structures.py
+++ b/pysonos/data_structures.py
@@ -1061,6 +1061,12 @@ class DidlPlaylistContainerFavorite(DidlPlaylistContainer):
     item_class = 'object.container.playlistContainer.sonos-favorite'
 
 
+class DidlPlaylistContainerTracklist(DidlPlaylistContainer):
+
+    """Class that represents a Sonos tracklist."""
+    item_class = 'object.container.playlistContainer.tracklist'
+
+
 class DidlGenre(DidlContainer):
 
     """A content directory class representing a general genre."""

--- a/pysonos/data_structures.py
+++ b/pysonos/data_structures.py
@@ -866,6 +866,12 @@ class DidlFavorite(DidlItem):
         self.resources = value.resources
 
 
+class DidlLineInItem(DidlItem):
+
+    """Class that represents a Sonos Line-In."""
+    item_class = 'object.item.audioItem.linein'
+
+
 ###############################################################################
 # OBJECT.CONTAINER HIERARCHY                                                  #
 ###############################################################################

--- a/pysonos/events.py
+++ b/pysonos/events.py
@@ -149,11 +149,11 @@ def parse_event_xml(xml_event):
                                 continue
                             value = didl[0]
                         except SoCoException as original_exception:
-                            log.debug("Event contains illegal metadata"
-                                      "for '%s'.\n"
-                                      "Error message: '%s'\n"
-                                      "The result will be a SoCoFault.",
-                                      tag, str(original_exception))
+                            log.warning("Event contains illegal metadata"
+                                        "for '%s'.\n"
+                                        "Error message: '%s'\n"
+                                        "The result will be a SoCoFault.",
+                                        tag, str(original_exception))
                             event_parse_exception = EventParseException(
                                 tag, value, original_exception
                             )


### PR DESCRIPTION
This adds `DidlLineInItem` and `DidlPlaylistContainerTracklist`, supporting Line-In favorites and Spotify Connect.

Includes SoCo/SoCo#645 and reverts #6 (so further omissions are easier to identify).