### PR TITLE
Allow much slower service calls

### DIFF
--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -469,10 +469,10 @@ class Service(object):
                 self.base_url + self.control_url,
                 headers=headers,
                 data=body.encode('utf-8'),
-                timeout=3,
+                timeout=20,
             )
-        except requests.exceptions.RequestException:
-            raise SoCoException('Connection error')
+        except requests.exceptions.RequestException as ex:
+            raise SoCoException('Connection error: ' + str(ex))
 
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -227,7 +227,7 @@ def test_send_command(service):
         assert result == {'CurrentLEDState': 'On', 'Unicode': "μИⅠℂ☺ΔЄ💋"}
         fake_post.assert_called_once_with(
             'http://192.168.1.101:1400/Service/Control',
-            headers=mock.ANY, data=DUMMY_VALID_ACTION.encode('utf-8'), timeout=3)
+            headers=mock.ANY, data=DUMMY_VALID_ACTION.encode('utf-8'), timeout=20)
         # Now the cache should be primed, so try it again
         fake_post.reset_mock()
         result = service.send_command('SetAVTransportURI', [


### PR DESCRIPTION
Back-pedal #23 a bit. Apparently, valid service calls [can take quite a while](https://github.com/home-assistant/home-assistant/issues/24532#issuecomment-503237709) so we must be more patient before declaring a connection error.

Also return more information about the the connection error if it finally does happen.