### PR TITLE
Catch client exceptions

### DIFF
--- a/pysonos/discovery.py
+++ b/pysonos/discovery.py
@@ -161,12 +161,15 @@ def _discover_thread(callback,
 def discover_thread(callback,
                     interval=60,
                     include_invisible=False,
-                    interface_addr=None):
+                    interface_addr=None,
+                    *,
+                    start=True):
     """ Return a started thread with a discovery callback. """
     thread = StoppableThread(
         target=_discover_thread,
         args=(callback, interval, include_invisible, interface_addr))
-    thread.start()
+    if start:
+        thread.start()
     return thread
 
 
@@ -220,7 +223,8 @@ def discover(timeout=5,
             thread.stop()
 
     thread = discover_thread(
-        callback, 2, include_invisible, interface_addr)
+        callback, 2, include_invisible, interface_addr, start=False)
+    thread.start()
     while thread.is_alive() and not thread.stopped():
         if first_response is None:
             thread.join(timeout=1)

--- a/pysonos/discovery.py
+++ b/pysonos/discovery.py
@@ -142,17 +142,28 @@ def _discover_thread(callback,
         # X-RINCON-HOUSEHOLD: Sonos_7O********************R7eU
 
         for _sock in response:
-            data, addr = _sock.recvfrom(1024)
-            _LOG.debug(
-                'Received discovery response from %s: "%s"', addr, data
-            )
-            if b"Sonos" in data:
+            try:
+                data, addr = _sock.recvfrom(1024)
+                _LOG.debug(
+                    'Received discovery response from %s: "%s"', addr, data
+                )
+
+                if b"Sonos" not in data:
+                    continue
+
                 # pylint: disable=not-callable
                 zone = config.SOCO_CLASS(addr[0])
-                if zone not in seen:
-                    seen.add(zone)
-                    if include_invisible or zone.is_visible:
-                        callback(zone)
+                if zone in seen:
+                    continue
+
+                seen.add(zone)
+
+                if include_invisible or zone.is_visible:
+                    callback(zone)
+
+            # pylint: disable=broad-except
+            except Exception as ex:
+                _LOG.debug('Error handling discovery response, ex=%s', ex)
 
     for _sock in _sockets.values():
         _sock.close()

--- a/pysonos/events.py
+++ b/pysonos/events.py
@@ -266,7 +266,12 @@ class EventNotifyHandler(BaseHTTPRequestHandler):
             # pylint: disable=protected-access
             service._update_cache_on_event(event)
             # Put the event on the queue
-            subscription.events.put(event)
+            try:
+                subscription.events.put(event)
+            # pylint: disable=broad-except
+            except Exception as ex:
+                log.debug('Error putting event %s, ex=%s', event, ex)
+
         else:
             log.debug("No service registered for %s", sid)
         self.send_response(200)


### PR DESCRIPTION
This should keep our threads from dying due to uncaught exceptions in client code.

Also fixes a race that was revealed by this change.