### PR TITLE
Lists 'sonos amp' as a soundbar in order to provide night mode and speech enhancement support for amp.

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -2158,7 +2158,7 @@ PLAY_MODES = {
 PLAY_MODE_BY_MEANING = {meaning: mode for mode, meaning in PLAY_MODES.items()}
 
 # soundbar product names
-SOUNDBARS = ('playbase', 'playbar', 'beam')
+SOUNDBARS = ('playbase', 'playbar', 'beam', 'sonos amp')
 
 if config.SOCO_CLASS is None:
     config.SOCO_CLASS = SoCo


### PR DESCRIPTION
Fixes #35740.

https://github.com/home-assistant/core/issues/35740