### PR TITLE
Retire Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-dist: xenial
+dist: focal
 
 language: python
 python:
-  - "3.6"
+  - "3.7"
   - "3.8"
 
 cache:


### PR DESCRIPTION
Already dropped by home-assistant/core#29978.