### PR TITLE
Discover all members of a group when we get an SSDP response

### DIFF
--- a/pysonos/discovery.py
+++ b/pysonos/discovery.py
@@ -156,12 +156,6 @@ def _discover_thread(callback, interval, include_invisible, interface_addr):
                 if b"Sonos" not in data:
                     continue
 
-                # Players can be discovered on multiple interfaces and
-                # we do not want to requery the same player once per interface
-                # if we recently polled it in this discovery
-                if addr[0] in seen:
-                    continue
-
                 # pylint: disable=not-callable
                 soco = config.SOCO_CLASS(addr[0])
 
@@ -171,10 +165,10 @@ def _discover_thread(callback, interval, include_invisible, interface_addr):
                     zones = soco.visible_zones
 
                 for zone in zones:
-                    if zone.ip_address in seen:
+                    if zone in seen:
                         continue
 
-                    seen.add(zone.ip_address)
+                    seen.add(zone)
 
                     if include_invisible or zone.is_visible:
                         with threading.current_thread().stop_lock:


### PR DESCRIPTION
- Solves issue where device does not respond when grouped
- Avoid query of the player when we have already seen the ip
  since responses can come from multiple interfaces. In a
  HomeAssistant OS install up to 4 responses per query will be
  received since there are multiple interfaces.

<img width="406" alt="Screen Shot 2021-04-05 at 1 02 48 PM" src="https://user-images.githubusercontent.com/663432/113638889-9b5c6200-9613-11eb-954f-57dcae052044.png">

cc @jjlawren
