### PR TITLE
Expand matches for pipe-delimited metadata

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -1503,8 +1503,8 @@ class SoCo(_SocoSingletonBase):
             if index > -1:
                 track["artist"] = trackinfo[:index]
                 track["title"] = trackinfo[index + 3 :]
-            elif trackinfo.startswith("BR P|TYPE=SNG"):
-                # Tagging used by e.g. SiriusXM:
+            elif re.search(r"(BR P\|)?TYPE=SNG\|.*", trackinfo):
+                # Tagging used by e.g. SiriusXM, Apple Music:
                 # "BR P|TYPE=SNG|TITLE 7.15.17 LA|ARTIST Eagles|ALBUM "
                 tags = dict([p.split(" ", 1) for p in trackinfo.split("|") if " " in p])
                 if tags.get("TITLE"):

--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -1503,9 +1503,12 @@ class SoCo(_SocoSingletonBase):
             if index > -1:
                 track["artist"] = trackinfo[:index]
                 track["title"] = trackinfo[index + 3 :]
-            elif re.search(r"(BR P\|)?TYPE=SNG\|.*", trackinfo):
-                # Tagging used by e.g. SiriusXM, Apple Music:
-                # "BR P|TYPE=SNG|TITLE 7.15.17 LA|ARTIST Eagles|ALBUM "
+            elif re.match(r"(BR P\|)?TYPE=SNG\|.*", trackinfo):
+                # Examples from services:
+                #  Apple Music radio:
+                #   "TYPE=SNG|TITLE Couleurs|ARTIST M83|ALBUM Saturdays = Youth"
+                #  SiriusXM:
+                #   "BR P|TYPE=SNG|TITLE 7.15.17 LA|ARTIST Eagles|ALBUM "
                 tags = dict([p.split(" ", 1) for p in trackinfo.split("|") if " " in p])
                 if tags.get("TITLE"):
                     track["title"] = tags["TITLE"]


### PR DESCRIPTION
Some services (i.e., Apple Music radio) use the existing pipe-delimited tagging but without a prefix like SiriusXM. This expands the matching to use the current decoder as-is.