### PR TITLE
Raise exceptions on aiohttp status in async event handler

### DIFF
--- a/pysonos/events_asyncio.py
+++ b/pysonos/events_asyncio.py
@@ -502,7 +502,7 @@ class Subscription(SubscriptionBase):
 
         async def _async_make_request():
             response = await self.event_listener.session.request(
-                method, url, headers=headers
+                method, url, headers=headers, raise_for_status=True
             )
             if response.ok:
                 success(response.headers)

--- a/pysonos/events_asyncio.py
+++ b/pysonos/events_asyncio.py
@@ -211,7 +211,7 @@ class EventListener(EventListenerBase):
             if not port:
                 return
             self.address = (ip_address, port)
-            self.session = ClientSession()
+            self.session = ClientSession(raise_for_status=True)
             self.is_running = True
             log.debug("Event Listener started")
 
@@ -502,7 +502,7 @@ class Subscription(SubscriptionBase):
 
         async def _async_make_request():
             response = await self.event_listener.session.request(
-                method, url, headers=headers, raise_for_status=True
+                method, url, headers=headers
             )
             if response.ok:
                 success(response.headers)


### PR DESCRIPTION
The current async events module does not actually raise `aiohttp` exceptions inside of `try:` blocks as the `raise_for_status` argument was missing. This can lead to problems such as failed subscription renewals being silently ignored.