### PR TITLE
Parse discovery packet, set boot seqnum attribute

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -275,6 +275,7 @@ class SoCo(_SocoSingletonBase):
         #: The speaker's ip address
         self.ip_address = ip_address
         self.speaker_info = {}  # Stores information about the current speaker
+        self.boot_seqnum = None
 
         # The services which we use
         # pylint: disable=invalid-name

--- a/pysonos/discovery.py
+++ b/pysonos/discovery.py
@@ -158,6 +158,12 @@ def _discover_thread(callback, interval, include_invisible, interface_addr):
 
                 # pylint: disable=not-callable
                 zone = config.SOCO_CLASS(addr[0])
+
+                data = data.decode("UTF-8")
+                header, payload = data.split("\r\n", 1)
+                fields = dict([f.split(":", 1) for f in payload.splitlines() if f])
+                zone.boot_seqnum = fields.get("X-RINCON-BOOTSEQ")
+
                 if zone in seen:
                     continue
 

--- a/pysonos/discovery.py
+++ b/pysonos/discovery.py
@@ -160,7 +160,7 @@ def _discover_thread(callback, interval, include_invisible, interface_addr):
                 zone = config.SOCO_CLASS(addr[0])
 
                 data = data.decode("UTF-8")
-                header, payload = data.split("\r\n", 1)
+                _, payload = data.split("\r\n", 1)
                 fields = dict([f.split(":", 1) for f in payload.splitlines() if f])
                 zone.boot_seqnum = fields.get("X-RINCON-BOOTSEQ")
 


### PR DESCRIPTION
There's a field in the discovery response payload which reports the number of power cycles for a given speaker. This exposes the value as a new attribute on the `soco.SoCo` instance if created from discovery.

This could be useful in determining if a speaker has lost power and needs its subscriptions recreated.