### PR TITLE
Revert some fixes

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -10,7 +10,6 @@ import re
 import socket
 from functools import wraps
 from xml.sax.saxutils import escape
-import xml.etree.ElementTree
 from xml.parsers.expat import ExpatError
 import warnings
 import xmltodict
@@ -1119,13 +1118,6 @@ class SoCo(_SocoSingletonBase):
             raise NotSupportedException from error
 
     def _parse_zone_group_state(self):
-        """Parse zone group state, catching some exceptions."""
-        try:
-            self.__parse_zone_group_state_wrapped()
-        except xml.etree.ElementTree.ParseError as ex:
-            raise SoCoException("Parse error: " + str(ex)) from ex
-
-    def __parse_zone_group_state_wrapped(self):
         """The Zone Group State contains a lot of useful information.
 
         Retrieve and parse it, and populate the relevant properties.
@@ -1212,12 +1204,8 @@ class SoCo(_SocoSingletonBase):
         # and the set of all members
         self._all_zones.clear()
         self._visible_zones.clear()
-        # The response is wrapped in ZoneGroups from Sonos 10.1
-        zonegroups = tree.find("ZoneGroups")
-        if zonegroups is not None:
-            tree = zonegroups
         # Loop over each ZoneGroup Element
-        for group_element in tree.findall("ZoneGroup"):
+        for group_element in tree.find("ZoneGroups").findall("ZoneGroup"):
             coordinator_uid = group_element.attrib["Coordinator"]
             group_uid = group_element.attrib["ID"]
             group_coordinator = None

--- a/pysonos/events_base.py
+++ b/pysonos/events_base.py
@@ -100,10 +100,7 @@ def parse_event_xml(xml_event):
                         # Wrap any parsing exception in a SoCoFault, so the
                         # user can handle it
                         try:
-                            didl = from_didl_string(value)
-                            if not didl:
-                                continue
-                            value = didl[0]
+                            value = from_didl_string(value)[0]
                         except SoCoException as original_exception:
                             log.debug(
                                 "Event contains illegal metadata"

--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -41,7 +41,7 @@ import requests
 from .cache import Cache
 from . import events
 from . import config
-from .exceptions import SoCoException, SoCoUPnPException, UnknownSoCoException
+from .exceptions import SoCoUPnPException, UnknownSoCoException
 from .utils import prettify
 from .xml import XML, illegal_xml_re
 
@@ -476,15 +476,12 @@ class Service:
         log.debug("Sending %s %s to %s", action, args, self.soco.ip_address)
         log.debug("Sending %s, %s", headers, prettify(body))
         # Convert the body to bytes, and send it.
-        try:
-            response = requests.post(
-                self.base_url + self.control_url,
-                headers=headers,
-                data=body.encode("utf-8"),
-                timeout=20,
-            )
-        except requests.exceptions.RequestException as ex:
-            raise SoCoException("Connection error: " + str(ex)) from ex
+        response = requests.post(
+            self.base_url + self.control_url,
+            headers=headers,
+            data=body.encode("utf-8"),
+            timeout=20,
+        )
 
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code
@@ -702,13 +699,9 @@ class Service:
                 name = state.findtext("{}name".format(ns))
                 datatype = state.findtext("{}dataType".format(ns))
                 default = state.findtext("{}defaultValue".format(ns))
-                value_list_elt = state.find("{}allowedValueList".format(ns))
-                if value_list_elt is None:
-                    value_list_elt = ()
+                value_list_elt = state.find("{}allowedValueList".format(ns)) or ()
                 value_list = [item.text for item in value_list_elt] or None
-                value_range_elt = state.find("{}allowedValueRange".format(ns))
-                if value_range_elt is None:
-                    value_range_elt = ()
+                value_range_elt = state.find("{}allowedValueRange".format(ns)) or ()
                 value_range = [item.text for item in value_range_elt] or None
                 vartypes[name] = Vartype(datatype, default, value_list, value_range)
         # find all the actions


### PR DESCRIPTION
I am currently upstreaming the remaining pysonos fixes to SoCo. However, there are some issues where I have not kept sufficient notes to reproduce and I am now unsure whether they are still relevant.

This PR _removes_ those fixes. If they are indeed still relevant we will have to rediscover that and will then be able to provide proper justification for SoCo to merge a fix.

* Might raise `xml.etree.ElementTree.ParseError` #41
* Breaks compatibility with Sonos firmware before 10.1 (which is now 2+ years old) #13
* Might raise IndexError #25
* Might raise `requests` exceptions #23
* Might log FutureWarning #19
