### PR TITLE
Revert log levels

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -1507,7 +1507,6 @@ class SoCo(_SocoSingletonBase):
             ]
         )
 
-    # pylint: disable=too-many-branches
     def get_current_track_info(self):
         """Get information about the currently playing track.
 

--- a/pysonos/data_structures_entry.py
+++ b/pysonos/data_structures_entry.py
@@ -96,7 +96,7 @@ def attempt_datastructure_upgrade(didl_item):
             # The data structure should be upgraded, but there is an entry
             # missing from DIDL_NAME_TO_QUALIFIED_MS_NAME. Log this as a
             # warning.
-            _LOG.debug(
+            _LOG.warning(
                 "DATA STRUCTURE UPGRADE FAIL. Unable to upgrade music library "
                 "data structure to music service data structure because an "
                 "entry is missing for %s in DIDL_NAME_TO_QUALIFIED_MS_NAME. "

--- a/pysonos/events.py
+++ b/pysonos/events.py
@@ -110,7 +110,7 @@ class EventNotifyHandler(BaseHTTPRequestHandler, EventNotifyHandlerBase):
 
     # pylint: disable=no-self-use, missing-docstring
     def log_event(self, seq, service_id, timestamp):
-        log.debug(
+        log.info(
             "Event %s received for %s service on thread %s at %s",
             seq,
             service_id,
@@ -145,7 +145,7 @@ class EventServerThread(threading.Thread):
         Handling of requests is delegated to an instance of the
         `EventNotifyHandler` class.
         """
-        log.debug("Event listener running on %s", self.server.server_address)
+        log.info("Event listener running on %s", self.server.server_address)
         # Listen for events until told to stop
         while not self.stop_flag.is_set():
             self.server.handle_request()
@@ -229,7 +229,7 @@ class EventListener(EventListenerBase):
         self._listener_thread.join(1)
         # check if join timed out and issue a warning if it did
         if self._listener_thread.is_alive():
-            log.debug("Event Listener did not shutdown gracefully.")
+            log.warning("Event Listener did not shutdown gracefully.")
 
 
 class Subscription(SubscriptionBase):

--- a/pysonos/events_asyncio.py
+++ b/pysonos/events_asyncio.py
@@ -152,7 +152,7 @@ class EventNotifyHandler(EventNotifyHandlerBase):
 
     # pylint: disable=no-self-use, missing-docstring
     def log_event(self, seq, service_id, timestamp):
-        log.debug("Event %s received for %s service at %s", seq, service_id, timestamp)
+        log.info("Event %s received for %s service at %s", seq, service_id, timestamp)
 
 
 class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-attributes
@@ -238,7 +238,7 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
         ):
             try:
                 if port_number > self.requested_port_number:
-                    log.debug("Trying next port (%d)", port_number)
+                    log.warning("Trying next port (%d)", port_number)
                 # pylint: disable=no-member
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.bind((ip_address, port_number))
@@ -248,7 +248,7 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
                 break
             # pylint: disable=invalid-name
             except socket.error as e:
-                log.debug(e)
+                log.warning(e)
                 continue
 
         if not self.port:
@@ -267,7 +267,7 @@ class EventListener(EventListenerBase):  # pylint: disable=too-many-instance-att
         await self.runner.setup()
         self.site = web.SockSite(self.runner, self.sock)
         await self.site.start()
-        log.debug("Event listener running on %s", (self.ip_address, self.port))
+        log.info("Event listener running on %s", (self.ip_address, self.port))
 
     async def async_stop(self):
         """Stop the listener."""

--- a/pysonos/events_base.py
+++ b/pysonos/events_base.py
@@ -102,7 +102,7 @@ def parse_event_xml(xml_event):
                         try:
                             value = from_didl_string(value)[0]
                         except SoCoException as original_exception:
-                            log.debug(
+                            log.warning(
                                 "Event contains illegal metadata"
                                 "for '%s'.\n"
                                 "Error message: '%s'\n"
@@ -244,7 +244,7 @@ class EventNotifyHandlerBase:
             # Pass the event on for handling
             subscription.send_event(event)
         else:
-            log.debug("No service registered for %s", sid)
+            log.info("No service registered for %s", sid)
 
     # pylint: disable=missing-docstring
     def log_event(self, seq, service_id, timestamp):
@@ -302,7 +302,7 @@ class EventListenerBase:
             return
         self.is_running = False
         self.stop_listening(self.address)
-        log.debug("Event Listener stopped")
+        log.info("Event Listener stopped")
 
     # pylint: disable=missing-docstring
     def listen(self, ip_address):
@@ -443,7 +443,7 @@ class SubscriptionBase:
                 self.timeout = int(timeout.lstrip("Second-"))
             self._timestamp = time.time()
             self.is_subscribed = True
-            log.debug(
+            log.info(
                 "Subscribed to %s, sid: %s",
                 service.base_url + service.event_subscription_url,
                 self.sid,
@@ -492,7 +492,7 @@ class SubscriptionBase:
             log_msg = "Autorenewing subscription %s"
         else:
             log_msg = "Renewing subscription %s"
-        log.debug(log_msg, self.sid)
+        log.info(log_msg, self.sid)
 
         if self._has_been_unsubscribed:
             raise SoCoException("Cannot renew subscription once unsubscribed")
@@ -523,7 +523,7 @@ class SubscriptionBase:
                 self.timeout = int(timeout.lstrip("Second-"))
             self._timestamp = time.time()
             self.is_subscribed = True
-            log.debug(
+            log.info(
                 "Renewed subscription to %s, sid: %s",
                 self.service.base_url + self.service.event_subscription_url,
                 self.sid,
@@ -561,7 +561,7 @@ class SubscriptionBase:
 
         # pylint: disable=missing-docstring, unused-argument
         def success(*arg):
-            log.debug(
+            log.info(
                 "Unsubscribed from %s, sid: %s",
                 self.service.base_url + self.service.event_subscription_url,
                 self.sid,
@@ -659,7 +659,7 @@ class SubscriptionBase:
         # Cancel any auto renew
         self._auto_renew_cancel()
         if msg:
-            log.debug(msg)
+            log.info(msg)
 
     @property
     def time_left(self):

--- a/pysonos/music_services/data_structures.py
+++ b/pysonos/music_services/data_structures.py
@@ -89,7 +89,7 @@ def get_class(class_key):
                 # So MediaMetadataTrack turns into MSTrack
                 class_name = "MS" + class_key.replace(basecls.__name__, "")
                 CLASSES[class_key] = type(class_name, (basecls,), {})
-                _LOG.debug("Class %s created", CLASSES[class_key])
+                _LOG.info("Class %s created", CLASSES[class_key])
     return CLASSES[class_key]
 
 

--- a/pysonos/music_services/music_service.py
+++ b/pysonos/music_services/music_service.py
@@ -531,7 +531,7 @@ class MusicService:
         if self.presentation_map_uri is None:
             # Assume not searchable?
             return self._search_prefix_map
-        log.debug("Fetching presentation map from %s", self.presentation_map_uri)
+        log.info("Fetching presentation map from %s", self.presentation_map_uri)
         pmap = requests.get(self.presentation_map_uri, timeout=9)
         pmap_root = XML.fromstring(pmap.content)
         # Search translations can appear in Category or CustomCategory elements

--- a/pysonos/plugins/__init__.py
+++ b/pysonos/plugins/__init__.py
@@ -21,7 +21,7 @@ class SoCoPlugin:
 
     def __init__(self, soco):
         cls = self.__class__.__name__
-        _LOG.debug("Initializing SoCo plugin %s", cls)
+        _LOG.info("Initializing SoCo plugin %s", cls)
         self.soco = soco
 
     @property
@@ -33,7 +33,7 @@ class SoCoPlugin:
     def from_name(cls, fullname, soco, *args, **kwargs):
         """Instantiate a plugin by its full name."""
 
-        _LOG.debug("Loading plugin %s", fullname)
+        _LOG.info("Loading plugin %s", fullname)
 
         parts = fullname.split(".")
         modname = ".".join(parts[:-1])
@@ -42,6 +42,6 @@ class SoCoPlugin:
         mod = importlib.import_module(modname)
         class_ = getattr(mod, clsname)
 
-        _LOG.debug("Loaded class %s", class_)
+        _LOG.info("Loaded class %s", class_)
 
         return class_(soco, *args, **kwargs)

--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -473,7 +473,7 @@ class Service:
             return result
         # Cache miss, so go ahead and make a network call
         headers, body = self.build_command(action, args)
-        log.debug("Sending %s %s to %s", action, args, self.soco.ip_address)
+        log.info("Sending %s %s to %s", action, args, self.soco.ip_address)
         log.debug("Sending %s, %s", headers, prettify(body))
         # Convert the body to bytes, and send it.
         response = requests.post(
@@ -485,7 +485,7 @@ class Service:
 
         log.debug("Received %s, %s", response.headers, response.text)
         status = response.status_code
-        log.debug("Received status %s from %s", status, self.soco.ip_address)
+        log.info("Received status %s from %s", status, self.soco.ip_address)
         if status == 200:
             # The response is good. Get the output params, and return them.
             # NB an empty dict is a valid result. It just means that no


### PR DESCRIPTION
This reverts the log levels to the ones used in SoCo. I will try to get some of the downgrades reintroduced through SoCo PRs.

Also included is a pylint disable that was missed in #93.