### PR TITLE
Workaround for pre-10.1 firmware versions

### DIFF
--- a/pysonos/core.py
+++ b/pysonos/core.py
@@ -1210,8 +1210,10 @@ class SoCo(_SocoSingletonBase):
         # and the set of all members
         self._all_zones.clear()
         self._visible_zones.clear()
+        # Compatibilty fix for pre-10.1 firmwares
+        tree = tree.find("ZoneGroups") or tree
         # Loop over each ZoneGroup Element
-        for group_element in tree.find("ZoneGroups").findall("ZoneGroup"):
+        for group_element in tree.findall("ZoneGroup"):
             coordinator_uid = group_element.attrib["Coordinator"]
             group_uid = group_element.attrib["ID"]
             group_coordinator = None


### PR DESCRIPTION
This re-adds a removed workaround (https://github.com/amelchio/pysonos/pull/13) which was reverted in https://github.com/amelchio/pysonos/pull/92. I don't have a way to test pre-10.1 speakers to validate, but it works fine with modern firmware versions.

If this works fine for HA users I'll resubmit to `SoCo`.

Original problem reported here: https://github.com/home-assistant/core/issues/52905.