### PR TITLE
Raise exception if Service command is not supported

### DIFF
--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -498,7 +498,7 @@ class Service:
             return result
         elif status == 405:
             raise NotSupportedException(
-                f"{action} not supported on {self.soco.ip_address}"
+                "{} not supported on {}".format(action, self.soco.ip_address)
             )
         elif status == 500:
             # Internal server error. UPnP requires this to be returned if the

--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -41,7 +41,7 @@ import requests
 from .cache import Cache
 from . import events
 from . import config
-from .exceptions import SoCoUPnPException, UnknownSoCoException
+from .exceptions import NotSupportedException, SoCoUPnPException, UnknownSoCoException
 from .utils import prettify
 from .xml import XML, illegal_xml_re
 
@@ -496,6 +496,10 @@ class Service:
             # error, since we would want to try a network call again.
             cache.put(result, action, args, timeout=cache_timeout)
             return result
+        elif status == 405:
+            raise NotSupportedException(
+                "%s not supported on %s", action, self.soco.ip_address
+            )
         elif status == 500:
             # Internal server error. UPnP requires this to be returned if the
             # device does not like the action for some reason. The returned

--- a/pysonos/services.py
+++ b/pysonos/services.py
@@ -498,7 +498,7 @@ class Service:
             return result
         elif status == 405:
             raise NotSupportedException(
-                "%s not supported on %s", action, self.soco.ip_address
+                f"{action} not supported on {self.soco.ip_address}"
             )
         elif status == 500:
             # Internal server error. UPnP requires this to be returned if the


### PR DESCRIPTION
As seen in https://github.com/home-assistant/core/issues/52716#issuecomment-884374637, Sonos Boost devices will reject certain service calls (e.g., `GetVolume`):
```
2021-07-21 13:09:00 DEBUG (SyncWorker_14) [pysonos.services] Dispatching method GetVolume
2021-07-21 13:09:00 DEBUG (SyncWorker_14) [pysonos.services] Sending GetVolume [('InstanceID', 0), ('Channel', 'Master')] to 192.168.0.34
2021-07-21 13:09:00 DEBUG (SyncWorker_14) [pysonos.services] Sending {'Content-Type': 'text/xml; charset="utf-8"', 'SOAPACTION': 'urn:schemas-upnp-org:service:RenderingControl:1#GetVolume'}, <?xml version="1.0" ?>
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
<s:Body>
<u:GetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">
<InstanceID>0</InstanceID>
<Channel>Master</Channel>
</u:GetVolume>
</s:Body>
</s:Envelope>
2021-07-21 13:09:00 DEBUG (SyncWorker_14) [pysonos.services] Received {'Allow': 'GET, HEAD', 'Content-type': 'text/html', 'Server': 'Linux UPnP/1.0 Sonos/63.2-90210 (BR200)', 'Connection': 'close'}, <HTML><HEAD><TITLE>Error 405</TITLE></HEAD><BODY><H1>Error 405</H1><P>Method Not Allowed</P></BODY></HTML>
2021-07-21 13:09:00 DEBUG (SyncWorker_14) [pysonos.services] Received status 405 from 192.168.0.34
2021-07-21 13:09:00 WARNING (SyncWorker_14) [homeassistant.components.sonos] Failed to connect to discovered player '192.168.0.34': 405 Client Error: Method Not Allowed for url: http://192.168.0.34:1400/MediaRenderer/RenderingControl/Control
```
When using the built-in discovery this was handled with a broad exception, but this is no longer used by Home Assistant: https://github.com/amelchio/pysonos/blob/51929502cc6b6f5eed6e716ef0ae7a0377252ed0/pysonos/discovery.py#L172-L173

This change will instead raise a more specific `NotSupportedException`.